### PR TITLE
Add command line options as_srec, as_ihex, as_hexdump

### DIFF
--- a/bincopy.py
+++ b/bincopy.py
@@ -1039,6 +1039,29 @@ def _do_info(args):
         f.add_file(binfile)
         print(f.info())
 
+def _do_hexdump(args):
+    for binfile in args.binfile:
+        f = BinFile()
+        f.add_file(binfile)
+        print(f.as_hexdump())
+
+def _do_ihex(args):
+    for binfile in args.binfile:
+        f = BinFile()
+        f.add_file(binfile)
+        print(f.as_ihex())
+
+def _do_binary(args):
+    for binfile in args.binfile:
+        f = BinFile()
+        f.add_file(binfile)
+        print(f.as_binary())
+
+def _do_srec(args):
+    for binfile in args.binfile:
+        f = BinFile()
+        f.add_file(binfile)
+        print(f.as_srec())
 
 def _main():
     parser = argparse.ArgumentParser(
@@ -1063,6 +1086,34 @@ def _main():
                              nargs='+',
                              help='One or more binary format files.')
     info_parser.set_defaults(func=_do_info)
+
+    # The 'as_hexdump' subparser.
+    hexdump_parser = subparsers.add_parser(
+        'as_hexdump',
+        description='Print hexdump to stdout.')
+    hexdump_parser.add_argument('binfile',
+                             nargs='+',
+                             help='One or more binary format files.')
+    hexdump_parser.set_defaults(func=_do_hexdump)
+
+    # The 'as_srec' subparser.
+    srec_parser = subparsers.add_parser(
+        'as_srec',
+        description='Print srec to stdout.')
+    srec_parser.add_argument('binfile',
+                             nargs='+',
+                             help='One or more binary format files.')
+    srec_parser.set_defaults(func=_do_srec)
+
+    # The 'as_ihex' subparser.
+    ihex_parser = subparsers.add_parser(
+        'as_ihex',
+        description='Print ihex to stdout.')
+    ihex_parser.add_argument('binfile',
+                             nargs='+',
+                             help='One or more binary format files.')
+    ihex_parser.set_defaults(func=_do_ihex)
+
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR allows for some fun things like running `meld <(bincopy as_hexdump before.s19) <(bincopy as_hexdump after.s19)`