### PR TITLE
Extended fill method with max_words parameter

### DIFF
--- a/bincopy.py
+++ b/bincopy.py
@@ -1331,8 +1331,14 @@ class BinFile(object):
 
         return '\n'.join(lines) + '\n'
 
-    def fill(self, value=b'\xff'):
+    def fill(self, value=b'\xff', max_words=None):
         """Fill all empty space between segments with given value `value`.
+        
+        `value` value which is used to fill the empty space.
+        
+        `max_words` maximal number of words to fill between the segments. Empty space
+        which is larger than this is not touched. If `None` is given, all empty space
+        is filled.
 
         """
 
@@ -1345,11 +1351,12 @@ class BinFile(object):
             if previous_segment_maximum_address is not None:
                 fill_size = address - previous_segment_maximum_address
                 fill_size_words = fill_size // self.word_size_bytes
-                fill_segments.append(_Segment(
-                    previous_segment_maximum_address,
-                    previous_segment_maximum_address + fill_size,
-                    value * fill_size_words,
-                    self.word_size_bytes))
+                if max_words is None or fill_size_words < max_words:
+                    fill_segments.append(_Segment(
+                        previous_segment_maximum_address,
+                        previous_segment_maximum_address + fill_size,
+                        value * fill_size_words,
+                        self.word_size_bytes))
 
             previous_segment_maximum_address = maximum_address
 

--- a/bincopy.py
+++ b/bincopy.py
@@ -1351,7 +1351,7 @@ class BinFile(object):
             if previous_segment_maximum_address is not None:
                 fill_size = address - previous_segment_maximum_address
                 fill_size_words = fill_size // self.word_size_bytes
-                if max_words is None or fill_size_words < max_words:
+                if max_words is None or fill_size_words <= max_words:
                     fill_segments.append(_Segment(
                         previous_segment_maximum_address,
                         previous_segment_maximum_address + fill_size,

--- a/tests/test_bincopy.py
+++ b/tests/test_bincopy.py
@@ -1105,6 +1105,23 @@ Data ranges:
         binfile.fill()
         self.assertEqual(binfile.as_binary(), b'')
 
+        # Add some data and fill again
+        binfile.add_binary(b'\x01\x02\x03\x04', address=0)
+        binfile.add_binary(b'\x01\x02\x03\x04', address=8)
+        binfile.fill()
+        self.assertEqual(binfile.as_binary(),
+                         b'\x01\x02\x03\x04\xff\xff\xff\xff\x01\x02\x03\x04')
+
+        # Fill with max words
+        binfile = bincopy.BinFile()
+        binfile.add_binary(b'\x01', address=0)
+        binfile.add_binary(b'\x02', address=2)
+        binfile.add_binary(b'\x03', address=5)
+        binfile.add_binary(b'\x04', address=9)
+        binfile.fill(value=b'\xaa', max_words=2)
+        self.assertEqual(binfile.as_binary(),
+                         b'\x01\xaa\x02\xaa\xaa\x03\xff\xff\xff\x04')
+
     def test_set_get_item(self):
         binfile = bincopy.BinFile()
 


### PR DESCRIPTION
Extended the fill method with a `max_words` parameter which can be used to define the maximal empty space which should be filled.
Holes wich are larger than the given size are not touched.