### PR TITLE
Let setup.py know that at least Python 3.6 is required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,10 @@ setup(name='bincopy',
       license='MIT',
       classifiers=[
           'License :: OSI Approved :: MIT License',
-          'Programming Language :: Python :: 2',
-          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
       ],
       keywords=['srecord',
                 'srec',
@@ -31,6 +33,7 @@ setup(name='bincopy',
           'humanfriendly',
           'argparse_addons>=0.4.0'
       ],
+      python_requires='>=3.6',
       test_suite="tests",
       entry_points = {
           'console_scripts': ['bincopy=bincopy:_main']


### PR DESCRIPTION
Python 2 and Python < 3.6 were dropped in favor of f-strings.

`setup.py` updated to reflect this.

The `bincopy` > 17 does not work on python 3.5 after [f-strings](https://www.python.org/dev/peps/pep-0498/) were introduced.

``` bash
pi@raspbian-stretch:~ $ python3 --version
Python 3.5.3
pi@raspbian-stretch:~ $ python3 -m bincopy --version
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 183, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.5/runpy.py", line 153, in _get_module_details
    code = loader.get_code(mod_name)
  File "<frozen importlib._bootstrap_external>", line 775, in get_code
  File "<frozen importlib._bootstrap_external>", line 735, in source_to_code
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/pi/.local/lib/python3.5/site-packages/bincopy.py", line 84
    line = f'{size + 2 + 1:02X}{address:04X}'
                                            ^
SyntaxError: invalid syntax
pi@raspbian-stretch:~ $ python3 -m pip show bincopy
Name: bincopy
Version: 17.8.0
Summary: Mangling of various file formats that conveys binary information (Motorola S-Record, Intel HEX and binary files).
Home-page: https://github.com/eerimoq/bincopy
Author: Erik Moqvist
Author-email: erik.moqvist@gmail.com
License: MIT
Location: /home/pi/.local/lib/python3.5/site-packages
Requires: argparse-addons, humanfriendly
```

Workaround for python 3.5 and friends, install  `bincopy` < 17 

``` bash
pi@raspbian-stretch:~ $ python3 -m pip install --upgrade bincopy==16.10
Collecting bincopy==16.10
  Downloading https://files.pythonhosted.org/packages/0a/44/ef4cab96d23323d28133e44e66a0930cbf4a346dcce3bcbf70a96a64f17a/bincopy-16.10.0-py2.py3-none-any.whl
Collecting humanfriendly (from bincopy==16.10)
  Using cached https://files.pythonhosted.org/packages/8e/2d/2f1b0a780b8c948c06c74c8c80e68ac354da52397ba432a1c5ac1923c3af/humanfriendly-8.2-py2.py3-none-any.whl
Installing collected packages: humanfriendly, bincopy
Successfully installed bincopy-17.8.0 humanfriendly-8.2
# Test
pi@raspbian-stretch:~ $ python3 -m bincopy --version
16.10.0
```