### PR TITLE
Add optional `padding` parameter to `chunks`

### DIFF
--- a/bincopy.py
+++ b/bincopy.py
@@ -676,20 +676,15 @@ class Segments:
         previous = Segment(-1, -1, b'', 1)
 
         for segment in self:
-            # When chunks are padded to alignment, the final chunk of the previous
-            # segment and the first chunk of the current segment may align to the
-            # same address. To avoid overwriting data from the lower segment, the
-            # chunks must be merged.
-            merge = previous.address == segment.address - segment.address % alignment
-
             for chunk in segment.chunks(size, alignment, padding):
-                # If padding is set, the first chunk's address can be less than the
-                # segment's.
-                if merge and chunk.address < segment.address:
-                    low = int.from_bytes(previous.data, 'big')
-                    high = int.from_bytes(chunk.data, 'big')
-                    null = int.from_bytes(size * padding, 'big')
-                    chunk.data = int.to_bytes(low ^ high ^ null,
+                # When chunks are padded to alignment, the final chunk of the previous
+                # segment and the first chunk of the current segment may align to the
+                # same address. To avoid overwriting data from the lower segment, the
+                # chunks must be merged.
+                if chunk.address == previous.address:
+                    chunk.data = int.to_bytes(int.from_bytes(previous.data, 'big') ^
+                                              int.from_bytes(chunk.data, 'big') ^
+                                              int.from_bytes(size * padding, 'big'),
                                               size * self.word_size_bytes, 'big')
 
                 yield chunk

--- a/bincopy.py
+++ b/bincopy.py
@@ -681,11 +681,14 @@ class Segments:
                 # segment and the first chunk of the current segment may align to the
                 # same address. To avoid overwriting data from the lower segment, the
                 # chunks must be merged.
-                if chunk.address == previous.address:
-                    chunk.data = int.to_bytes(int.from_bytes(previous.data, 'big') ^
-                                              int.from_bytes(chunk.data, 'big') ^
-                                              int.from_bytes(size * padding, 'big'),
-                                              size * self.word_size_bytes, 'big')
+                if chunk.address < previous.address + len(previous):
+                    low = previous.data[-alignment // self.word_size_bytes:]
+                    high = chunk.data[:alignment // self.word_size_bytes]
+                    merged = int.to_bytes(int.from_bytes(low, 'big') ^
+                                          int.from_bytes(high, 'big') ^
+                                          int.from_bytes(alignment * padding, 'big'),
+                                          alignment * self.word_size_bytes, 'big')
+                    chunk.data = merged + chunk.data[alignment // self.word_size_bytes:]
 
                 yield chunk
 

--- a/bincopy.py
+++ b/bincopy.py
@@ -367,7 +367,7 @@ class Segment:
         Each chunk is itself a Segment.
 
         `size` and `alignment` are in words. `size` must be a multiple of
-        `alignment`.
+        `alignment`. If set, `padding` must be a word value.
 
         If `padding` is set, the first and final chunks are padded so that:
             1. The first chunk is aligned even if the segment itself is not.
@@ -379,7 +379,8 @@ class Segment:
             raise Error(f'size {size} is not a multiple of alignment {alignment}')
 
         if padding and len(padding) != self.word_size_bytes:
-            raise Error(f'padding must be same length as word ({self.word_size_bytes})')
+            raise Error(f'padding must be a word value (size {self.word_size_bytes}),'
+                        f' got {padding}')
 
         size *= self.word_size_bytes
         alignment *= self.word_size_bytes
@@ -656,7 +657,7 @@ class Segments:
         Each chunk is itself a Segment.
 
         `size` and `alignment` are in words. `size` must be a multiple of
-        `alignment`.
+        `alignment`. If set, `padding` must be a word value.
 
         If `padding` is set, the first and final chunks of each segment are
         padded so that:
@@ -669,7 +670,8 @@ class Segments:
             raise Error(f'size {size} is not a multiple of alignment {alignment}')
 
         if padding and len(padding) != self.word_size_bytes:
-            raise Error(f'padding must be same length as word ({self.word_size_bytes})')
+            raise Error(f'padding must be a word value (size {self.word_size_bytes}),'
+                        f' got {padding}')
 
         for segment in self:
             for chunk in segment.chunks(size, alignment, padding):

--- a/bincopy.py
+++ b/bincopy.py
@@ -678,17 +678,17 @@ class Segments:
         for segment in self:
             for chunk in segment.chunks(size, alignment, padding):
                 # When chunks are padded to alignment, the final chunk of the previous
-                # segment and the first chunk of the current segment may align to the
-                # same address. To avoid overwriting data from the lower segment, the
-                # chunks must be merged.
+                # segment and the first chunk of the current segment may overlap by
+                # one alignment block. To avoid overwriting data from the lower
+                # segment, the chunks must be merged.
                 if chunk.address < previous.address + len(previous):
-                    low = previous.data[-alignment // self.word_size_bytes:]
-                    high = chunk.data[:alignment // self.word_size_bytes]
+                    low = previous.data[-alignment * self.word_size_bytes:]
+                    high = chunk.data[:alignment * self.word_size_bytes]
                     merged = int.to_bytes(int.from_bytes(low, 'big') ^
                                           int.from_bytes(high, 'big') ^
                                           int.from_bytes(alignment * padding, 'big'),
                                           alignment * self.word_size_bytes, 'big')
-                    chunk.data = merged + chunk.data[alignment // self.word_size_bytes:]
+                    chunk.data = merged + chunk.data[alignment * self.word_size_bytes:]
 
                 yield chunk
 

--- a/bincopy.py
+++ b/bincopy.py
@@ -689,7 +689,8 @@ class Segments:
                     low = int.from_bytes(previous.data, 'big')
                     high = int.from_bytes(chunk.data, 'big')
                     null = int.from_bytes(size * padding, 'big')
-                    chunk.data = int.to_bytes(low ^ high ^ null, size, 'big')
+                    chunk.data = int.to_bytes(low ^ high ^ null,
+                                              size * self.word_size_bytes, 'big')
 
                 yield chunk
 

--- a/bincopy.py
+++ b/bincopy.py
@@ -362,7 +362,7 @@ class Segment:
         return self.minimum_address // self.word_size_bytes
 
     def chunks(self, size=32, alignment=1, padding=b''):
-        """Return chunks of the data aligned as given by `alignment`. `size`
+        """Yield chunks of the data aligned as given by `alignment`. `size`
         must be a multiple of `alignment`. Optionally, the first and final
         chunks can be padded to make them conform to `size` and `alignment`.
         Each chunk is itself a Segment. Both `size` and `alignment` are in
@@ -372,7 +372,7 @@ class Segment:
 
         if (size % alignment) != 0:
             raise Error(f'size {size} is not a multiple of alignment {alignment}')
-        
+
         if len(padding) > 1:
             raise Error('padding must be a single byte value or empty')
 
@@ -642,15 +642,20 @@ class Segments:
         self._list = new_list
 
     def chunks(self, size=32, alignment=1, padding=b''):
-        """Iterate over all segments and return chunks of the data aligned as
-        given by `alignment`. `size` must be a multiple of
-        `alignment`. Each chunk is in turn a smaller Segment. Both `size` and
-        `alignment` are in words.
+        """Iterate over all segments and yield chunks of the data aligned as
+        given by `alignment`. Optionally, the first and final chunks can be
+        padded to make them conform to `size` and `alignment`. `size` must be
+        a multiple of `alignment`. Each chunk is in turn a smaller Segment.
+        Both `size` and `alignment` are in words, `padding` is a single byte
+        or empty.
 
         """
 
         if (size % alignment) != 0:
             raise Error(f'size {size} is not a multiple of alignment {alignment}')
+
+        if len(padding) > 1:
+            raise Error('padding must be a single byte value or empty')
 
         for segment in self:
             for chunk in segment.chunks(size, alignment, padding):

--- a/tests/test_bincopy.py
+++ b/tests/test_bincopy.py
@@ -1882,15 +1882,15 @@ Data ranges:
         assert not any(len(c) % align for c in chunks)
 
     def test_merge_chunks(self):
-        records = (':0100000010EF\n'
-                   ':0100020020DD\n')
+        records = (':0A0000001010101010101010101056\n'
+                   ':0A000E001010101010101010101048\n')
         hexfile = bincopy.BinFile()
         hexfile.add_ihex(records)
-        align = 4
-        size = 4
+        align = 8
+        size = 16
         chunks = hexfile.segments.chunks(size=size, alignment=align, padding=b'\xff')
         chunks = list(chunks)
-        assert chunks[-1].data == b'\x10\xff \xff'
+        assert list(chunks[-1]) == [8, b'\x10\x10\xff\xff\xff\xff\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10']
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_bincopy.py
+++ b/tests/test_bincopy.py
@@ -911,10 +911,10 @@ class BinCopyTest(unittest.TestCase):
                          'size 4 is not a multiple of alignment 8')
 
         with self.assertRaises(bincopy.Error) as cm:
-            list(binfile.segments.chunks(padding=b'\xff\x00'))
+            list(binfile.segments.chunks(padding=b'\xff\xff'))
 
         self.assertEqual(str(cm.exception),
-                         'padding must be a single byte value or empty')
+                         'padding must be same length as word (1)')
 
     def test_segment(self):
         binfile = bincopy.BinFile()
@@ -1876,10 +1876,10 @@ Data ranges:
         hexfile.add_ihex(records)
         align = 8
         size = 16
-        chunks = hexfile.segments.chunks(size=16, alignment=align, padding=b'\xff')
+        chunks = hexfile.segments.chunks(size=size, alignment=align, padding=b'\xff')
         chunks = list(chunks)
         assert not any(c.address % align for c in chunks)
-        assert all(len(c) == size for c in chunks)
+        assert not any(len(c) % align for c in chunks)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_bincopy.py
+++ b/tests/test_bincopy.py
@@ -1881,5 +1881,16 @@ Data ranges:
         assert not any(c.address % align for c in chunks)
         assert not any(len(c) % align for c in chunks)
 
+    def test_merge_chunks(self):
+        records = (':0100000010EF\n'
+                   ':0100020020DD\n')
+        hexfile = bincopy.BinFile()
+        hexfile.add_ihex(records)
+        align = 4
+        size = 4
+        chunks = hexfile.segments.chunks(size=size, alignment=align, padding=b'\xff')
+        chunks = list(chunks)
+        assert chunks[-1].data == b'\x10\xff \xff'
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_bincopy.py
+++ b/tests/test_bincopy.py
@@ -1863,6 +1863,17 @@ Data ranges:
         first_word = int.from_bytes(binfile[:binfile.minimum_address + 1], 'little')
         self.assertEqual(0xC9E4, first_word)
 
+    def test_chunk_padding(self):
+        records = (':02000004000AF0\n'
+                   ':10B8440000000000000000009630000007770000B0\n')
+        hexfile = bincopy.BinFile()
+        hexfile.add_ihex(records)
+        align = 8
+        size = 16
+        chunks = hexfile.segments.chunks(size=16, alignment=align, padding=b'\xff')
+        chunks = list(chunks)
+        assert not any(c.address % align for c in chunks)
+        assert all(len(c) == size for c in chunks)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_bincopy.py
+++ b/tests/test_bincopy.py
@@ -910,6 +910,12 @@ class BinCopyTest(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          'size 4 is not a multiple of alignment 8')
 
+        with self.assertRaises(bincopy.Error) as cm:
+            list(binfile.segments.chunks(padding=b'\xff\x00'))
+
+        self.assertEqual(str(cm.exception),
+                         'padding must be a single byte value or empty')
+
     def test_segment(self):
         binfile = bincopy.BinFile()
         binfile.add_binary(b'\x00\x01\x02\x03\x04', 2)

--- a/tests/test_bincopy.py
+++ b/tests/test_bincopy.py
@@ -1892,5 +1892,17 @@ Data ranges:
         chunks = list(chunks)
         assert list(chunks[-1]) == [8, b'\x10\x10\xff\xff\xff\xff\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10']
 
+    def test_merge_chunks_16(self):
+        records = (':1000000010101010101010101010101010101010F0\n'
+                   ':10000A0010101010101010101010101010101010E6\n')
+        hexfile = bincopy.BinFile(word_size_bits=16)
+        hexfile.add_ihex(records)
+        align = 6
+        size = 12
+        chunks = hexfile.segments.chunks(size=size, alignment=align, padding=b'\xff\xff')
+        chunks = list(chunks)
+        assert list(chunks[-1]) == [6, b'\x10\x10\x10\x10\xff\xff\xff\xff\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10']
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_bincopy.py
+++ b/tests/test_bincopy.py
@@ -914,7 +914,7 @@ class BinCopyTest(unittest.TestCase):
             list(binfile.segments.chunks(padding=b'\xff\xff'))
 
         self.assertEqual(str(cm.exception),
-                         'padding must be same length as word (1)')
+                         r"padding must be a word value (size 1), got b'\xff\xff'")
 
     def test_segment(self):
         binfile = bincopy.BinFile()

--- a/tests/test_bincopy.py
+++ b/tests/test_bincopy.py
@@ -1890,7 +1890,8 @@ Data ranges:
         size = 16
         chunks = hexfile.segments.chunks(size=size, alignment=align, padding=b'\xff')
         chunks = list(chunks)
-        assert list(chunks[-1]) == [8, b'\x10\x10\xff\xff\xff\xff\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10']
+        assert list(chunks[-1]) == [8, b'\x10\x10\xff\xff\xff\xff\x10\x10\x10\x10\x10'
+                                       b'\x10\x10\x10\x10\x10']
 
     def test_merge_chunks_16(self):
         records = (':1000000010101010101010101010101010101010F0\n'
@@ -1899,9 +1900,12 @@ Data ranges:
         hexfile.add_ihex(records)
         align = 6
         size = 12
-        chunks = hexfile.segments.chunks(size=size, alignment=align, padding=b'\xff\xff')
+        chunks = hexfile.segments.chunks(size=size, alignment=align,
+                                         padding=b'\xff\xff')
         chunks = list(chunks)
-        assert list(chunks[-1]) == [6, b'\x10\x10\x10\x10\xff\xff\xff\xff\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10']
+        assert list(chunks[-1]) == [6, b'\x10\x10\x10\x10\xff\xff\xff\xff\x10\x10\x10'
+                                       b'\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10'
+                                       b'\x10\x10']
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If `padding` is given, the first and final chunks are padded to conform to `size` and `alignment`, which is otherwise not guaranteed.

Close #40.