### PR TITLE
Add `BinFile.as_microchip_hex`

### DIFF
--- a/bincopy.py
+++ b/bincopy.py
@@ -1426,6 +1426,39 @@ class BinFile:
 
         return '\n'.join(data_address + footer) + '\n'
 
+    def as_microchip_hex(self, number_of_data_bytes=32, address_length_bits=32):
+        """Format the binary file as Microchip HEX records and return them as a
+        string.
+
+        `number_of_data_bytes` is the number of data bytes in each
+        record.
+
+        `address_length_bits` is the number of address bits in each
+        record.
+
+        >>> print(binfile.as_microchip_hex())
+        :20010000214601360121470136007EFE09D219012146017E17C20001FF5F16002148011979
+        :20012000194E79234623965778239EDA3F01B2CA3F0156702B5E712B722B7321460134219F
+        :00000001FF
+
+        """
+
+        self.word_size_bytes = 1
+        self.segments.word_size_bytes = 1
+
+        for segment in self.segments:
+            segment.word_size_bytes = 1
+
+        records = self.as_ihex(number_of_data_bytes, address_length_bits)
+
+        self.word_size_bytes = 2
+        self.segments.word_size_bytes = 2
+
+        for segment in self.segments:
+            segment.word_size_bytes = 2
+
+        return records
+
     def as_ti_txt(self):
         """Format the binary file as a TI-TXT file and return it as a string.
 

--- a/tests/test_bincopy.py
+++ b/tests/test_bincopy.py
@@ -1869,6 +1869,23 @@ Data ranges:
         first_word = int.from_bytes(binfile[:binfile.minimum_address + 1], 'little')
         self.assertEqual(0xC9E4, first_word)
 
+    def test_microchip_hex(self):
+        binfile = bincopy.BinFile()
+
+        with open("tests/files/in.hex", "r") as fin:
+            binfile.add_microchip_hex(fin.read())
+
+        with open("tests/files/in.hex", "r") as fin:
+            self.assertEqual(binfile.as_microchip_hex(), fin.read())
+
+        # Add and overwrite the data.
+        binfile = bincopy.BinFile()
+        binfile.add_microchip_hex_file("tests/files/in.hex")
+        binfile.add_microchip_hex_file("tests/files/in.hex", overwrite=True)
+
+        with open("tests/files/in.hex") as fin:
+            self.assertEqual(binfile.as_microchip_hex(), fin.read())
+
     def test_chunk_padding(self):
         records = (':02000004000AF0\n'
                    ':10B8440000000000000000009630000007770000B0\n')


### PR DESCRIPTION
This PR adds `BinFile.as_microchip_hex`, complementing `.add_microchip_hex`. Other formats provide both `.add_X` and `.as_X` methods, so the currently missing `.as_microchip_hex` is incongruous.