### PR TITLE
Adds conversion to bytearray within Segment

### DIFF
--- a/bincopy.py
+++ b/bincopy.py
@@ -354,7 +354,7 @@ class Segment:
     def __init__(self, minimum_address, maximum_address, data, word_size_bytes):
         self.minimum_address = minimum_address
         self.maximum_address = maximum_address
-        self.data = data
+        self.data = bytearray(data)
         self.word_size_bytes = word_size_bytes
 
     @property

--- a/tests/test_bincopy.py
+++ b/tests/test_bincopy.py
@@ -1810,6 +1810,15 @@ Data ranges:
         with open('tests/files/elf/keil.bin', 'rb') as fin:
             self.assertEqual(bf.as_binary(), fin.read())
 
+    def test_add_elf_modify_overwrite(self):
+        bf = bincopy.BinFile()
+        bf.add_elf_file('tests/files/elf.out')
+
+        data = b'test'
+        address = bf.minimum_address
+        bf.add_binary(data, address=address, overwrite=True)
+        self.assertEqual(data, bf.as_binary(minimum_address=address, maximum_address=address+len(data)))
+
     def test_exclude_edge_cases(self):
         binfile = bincopy.BinFile()
         binfile.add_binary(b'1234', address=10)


### PR DESCRIPTION
Fix for #53 

Previously, depending on how a Segment was created, the internal data may have been stored as an immutable bytes object. This caused issues with modifying operations.

Now, the best I've found to come up with an as small as possible fix was a simple conversion to bytearray within `Segment.__init__()`. 

I've also checked out python type-hints, but these do not enforce a type during runtime.

I can not guarantee that `self.data` will never be internally assigned a bytes object in some obscure way. (And I unfortunately don't have enough time to do a full analysis to catch every edge-case). For a sanity check I modified the Segment equal operator and executed all tests
```python
def __eq__(self, other):
        print(type(self.data) == type(bytearray()))
```
Before change: I got a mix of True and False, newly added unit test was failed
After change: I only saw True, newly added unit test succeeded

On my end all unit tests are successful.

Hope it helps, and let me know if you need anything else for this PR.


