### PR TITLE
Add BincopySharp to similar projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,6 +194,8 @@ These projects provides features similar to bincopy:
 
 - `objutils`_ (Process HEX files in Python)
 
+- `BincopySharp`_ (C# library inspired by bincopy)
+
 .. _test suite: https://github.com/eerimoq/bincopy/blob/master/tests/test_bincopy.py
 
 .. _SRecord: http://srecord.sourceforge.net/
@@ -201,3 +203,5 @@ These projects provides features similar to bincopy:
 .. _IntelHex: https://github.com/python-intelhex/intelhex
 
 .. _objutils: https://github.com/christoph2/objutils
+
+.. _BincopySharp: https://github.com/alf-tg/BincopySharp


### PR DESCRIPTION
Adds BincopySharp, a C# library inspired by bincopy, to the "Similar projects" section of the README.

Closes #56